### PR TITLE
Fix package name mismatches

### DIFF
--- a/MK_SSL/__init__.py
+++ b/MK_SSL/__init__.py
@@ -1,2 +1,2 @@
-__name__ = "AK_SSL"
+__name__ = "MK_SSL"
 __version__ = "0.2.0"

--- a/MK_SSL/audio/Trainer.py
+++ b/MK_SSL/audio/Trainer.py
@@ -56,7 +56,7 @@ class Trainer:
 
         self.logger.info(
             "\n"
-            "---------------- AK_SSL: Audio ----------------\n"
+            "---------------- MK_SSL: Audio ----------------\n"
             f"Number of workers : {self.num_workers}\n"
             f"Device            : {self.device}\n"
             f"Method            : {self.method}\n"

--- a/MK_SSL/audio/models/modules/tools/__init__.py
+++ b/MK_SSL/audio/models/modules/tools/__init__.py
@@ -1,3 +1,3 @@
-from AK_SSL.audio.models.modules.tools.pseudo_label_generator import PseudoLabelGenerator
+from MK_SSL.audio.models.modules.tools.pseudo_label_generator import PseudoLabelGenerator
 
 __all__ = ["PseudoLabelGenerator"]

--- a/MK_SSL/audio/models/modules/wav2vec2_backbone.py
+++ b/MK_SSL/audio/models/modules/wav2vec2_backbone.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 from torch import Tensor
 from typing import Optional
 
-from AK_SSL.audio.models.wav2vec2 import Wav2Vec2
+from MK_SSL.audio.models.wav2vec2 import Wav2Vec2
 
 
 class Wav2Vec2Backbone(nn.Module):

--- a/MK_SSL/multimodal/Trainer.py
+++ b/MK_SSL/multimodal/Trainer.py
@@ -85,7 +85,7 @@ class Trainer:
 
         self.logger.info(
             "\n"
-            "---------------- AK_SSL: Multimodal ----------------\n"
+            "---------------- MK_SSL: Multimodal ----------------\n"
             f"Number of workers : {self.num_workers}\n"
             f"Device            : {self.device}\n"
             f"Method            : {self.method}\n"

--- a/MK_SSL/vision/Trainer.py
+++ b/MK_SSL/vision/Trainer.py
@@ -110,7 +110,7 @@ class Trainer:
 
         self.logger.info(
             "\n"
-            "---------------- AK_SSL: Vision ----------------\n"
+            "---------------- MK_SSL: Vision ----------------\n"
             f"Number of workers : {self.num_workers}\n"
             f"Device            : {self.device}\n"
             f"Method            : {self.method}\n"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## 📂 Project Structure
 
 ```
-AK_SSL/
+MK_SSL/
 │
 ├── audio/
 │   ├── models/
@@ -43,7 +43,7 @@ Stay tuned for more updates!
 ## 🧪 Usage Examples (Coming Soon)
 
 ```python
-from AK_SSL.audio.models import SimCLRSpeech
+from MK_SSL.audio.models import SimCLRSpeech
 
 model = SimCLRSpeech(variant="base")
 # model.forward(...)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ _PATH_ROOT = Path(os.path.dirname(__file__))
 
 
 def load_version() -> str:
-    version_filepath = _PATH_ROOT / "AK_SSL" / "__init__.py"
+    version_filepath = _PATH_ROOT / "MK_SSL" / "__init__.py"
     with version_filepath.open() as file:
         for line in file.readlines():
             if line.startswith("__version__"):
@@ -17,7 +17,7 @@ def load_version() -> str:
 
 
 if __name__ == "__main__":
-    name = "AK_SSL"
+    name = "MK_SSL"
     version = load_version()
     author = "Audrina Ebrahimi & Kian Majlessi"
     author_email = "audrina_ebrahimi@outlook.com"
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     packages = setuptools.find_packages()
 
     project_urls = {
-        "Github": "https://github.com/audrina-ebrahimi/AK_SSL",
+        "Github": "https://github.com/audrina-ebrahimi/MK_SSL",
     }
 
     classifiers = [


### PR DESCRIPTION
## Summary
- clean up inconsistent references to `AK_SSL`
- adjust README to use `MK_SSL` package name
- fix import paths in audio utilities
- update logging banners
- correct setup path and metadata

## Testing
- `python -m compileall -q MK_SSL`

------
https://chatgpt.com/codex/tasks/task_e_686866b689308326bcd435ef2ef70cc8