### PR TITLE
Fix wav2vec2 mask comment

### DIFF
--- a/MK_SSL/audio/models/wav2vec2.py
+++ b/MK_SSL/audio/models/wav2vec2.py
@@ -223,7 +223,7 @@ class Wav2Vec2(nn.Module):
         time_mask_indices = time_mask_indices[:, :-self.num_mask_time_steps]
         num_masks = sum(time_mask_indices.flatten())
 
-        # Maks hidden states
+        # Mask hidden states
         mask_values = torch.zeros(num_masks, hidden_size, device=hidden_states.device)
         hidden_states[time_mask_indices] = mask_values
 


### PR DESCRIPTION
## Summary
- fix a typo in the masking comment for the wav2vec2 model

## Testing
- `python -m compileall -q MK_SSL`

------
https://chatgpt.com/codex/tasks/task_e_68686947ff7c83268f6b86342ef81c66